### PR TITLE
fix: キーを素早く連打しても音が鳴るよう修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,20 +6,18 @@ import pallet from "./config/pallet";
 
 const root = document.body;
 const grid = { colum: 14, row: 4 } as const;
-const oscillators = Array.from(
+const notes = Array.from(
   { length: grid.colum * grid.row },
-  (_, i) =>
-    new Oscillator(
-      `${"CDEFGAB"[i % 7]}${Math.floor(i / 7)}`,
-      "square"
-    ).toDestination()
+  (_, i) => `${"CDEFGAB"[i % 7]}${Math.floor(i / 7)}`
 );
 const canvas = document.createElement("canvas");
 const ctx = canvas.getContext("2d")!;
 
-function tone(osc: Oscillator) {
+function tone(note: string) {
+  const osc = new Oscillator(note, "square").toDestination();
   osc.start();
   osc.stop("+0.05");
+  setTimeout(() => osc.dispose(), 200);
 }
 
 function draw(px: number, py: number) {
@@ -31,10 +29,7 @@ function draw(px: number, py: number) {
     return;
   }
 
-  try {
-    // FIXME: Error: Start time must be strictly greater than previous start time.
-    tone(oscillators[(grid.row - 1 - screenRow) * grid.colum + col]!);
-  } catch {}
+  tone(notes[(grid.row - 1 - screenRow) * grid.colum + col]!);
 
   const offset = () => 0.05 * (Math.random() - 0.5);
   const width = (0.08 + offset()) * canvas.height;


### PR DESCRIPTION
## 原因

`Oscillator` インスタンスをキーごとに1つ保持して再利用していたため、50ms以内に同じキーを再度押すと `osc.start()` が以下のエラーを送出していた。

> Error: Start time must be strictly greater than previous start time.

このエラーが `try-catch {}` で無音のまま握り潰されることで、キー入力しても音が鳴らない現象が発生していた。

## 修正内容

- `Oscillator` インスタンスの配列をノート名の配列に変更
- `tone()` を呼ぶたびに新しい `Oscillator` を生成・起動・停止後に `dispose()` する方式に変更
- 不要になった `try-catch` を削除

これにより、連打時も必ず新しいオシレーターが使われるため確実に音が鳴る。

---
_Generated by [Claude Code](https://claude.ai/code/session_0182JcxiC5MDdM8xTbn4hZwQ)_