### PR TITLE
fix: AudioContextがsuspendedのとき音が鳴らない問題を修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Oscillator } from "tone";
+import { Oscillator, start as toneStart, getContext } from "tone";
 import randomInt from "./randomInt";
 import keyPosition from "./keyPosition";
 import keyLayouts from "./config/keyLayouts";
@@ -14,10 +14,17 @@ const canvas = document.createElement("canvas");
 const ctx = canvas.getContext("2d")!;
 
 function tone(note: string) {
-  const osc = new Oscillator(note, "square").toDestination();
-  osc.start();
-  osc.stop("+0.05");
-  setTimeout(() => osc.dispose(), 200);
+  const play = () => {
+    const osc = new Oscillator(note, "square").toDestination();
+    osc.start();
+    osc.stop("+0.05");
+    setTimeout(() => osc.dispose(), 200);
+  };
+  if (getContext().state === "running") {
+    play();
+  } else {
+    void toneStart().then(play);
+  }
 }
 
 function draw(px: number, py: number) {


### PR DESCRIPTION
## 原因

ブラウザは以下のタイミングで AudioContext を `suspended` 状態にする。

- ページ読み込み直後（ユーザー操作前）
- タブが非アクティブになった後

この状態で `osc.start()` を呼ぶと発音はスケジュールされるだけで実際には鳴らず、50ms の `stop()` ウィンドウが過ぎてしまうため無音になっていた。コードが一度も `Tone.start()` を呼んでいなかったことが根本原因。

## 修正内容

`tone()` の中で AudioContext の状態を確認し：

- `running` → そのまま同期的に発音（追加レイテンシゼロ）
- `suspended` → `toneStart()` でレジュームしてから発音

これにより、初回押下・タブ復帰後の押下でも確実に音が鳴る。通常の連打時はコンテキストが `running` なので同期パスを通り、レイテンシへの影響はない。

---
_Generated by [Claude Code](https://claude.ai/code/session_0182JcxiC5MDdM8xTbn4hZwQ)_